### PR TITLE
Implement ROBOT reduce command

### DIFF
--- a/src/main/java/edu/stanford/protege/robot/command/RobotCommand.java
+++ b/src/main/java/edu/stanford/protege/robot/command/RobotCommand.java
@@ -10,6 +10,7 @@ import edu.stanford.protege.robot.command.expand.RobotExpandCommand;
 import edu.stanford.protege.robot.command.export.RobotExportCommand;
 import edu.stanford.protege.robot.command.extract.RobotExtractCommand;
 import edu.stanford.protege.robot.command.filter.RobotFilterCommand;
+import edu.stanford.protege.robot.command.reduce.RobotReduceCommand;
 import edu.stanford.protege.robot.command.relax.RobotRelaxCommand;
 import edu.stanford.protege.robot.command.remove.RobotRemoveCommand;
 import edu.stanford.protege.robot.command.repair.RobotRepairCommand;
@@ -28,6 +29,7 @@ import org.obolibrary.robot.Command;
     @JsonSubTypes.Type(RobotExpandCommand.class),
     @JsonSubTypes.Type(RobotExportCommand.class),
     @JsonSubTypes.Type(RobotFilterCommand.class),
+    @JsonSubTypes.Type(RobotReduceCommand.class),
     @JsonSubTypes.Type(RobotRelaxCommand.class),
     @JsonSubTypes.Type(RobotRemoveCommand.class),
     @JsonSubTypes.Type(RobotRepairCommand.class)})

--- a/src/main/java/edu/stanford/protege/robot/command/common/Reasoner.java
+++ b/src/main/java/edu/stanford/protege/robot/command/common/Reasoner.java
@@ -1,0 +1,73 @@
+package edu.stanford.protege.robot.command.common;
+
+/**
+ * Supported OWL reasoners for ROBOT commands.
+ *
+ * <p>
+ * Many ROBOT commands require a reasoner for tasks like consistency checking, classification,
+ * and entailment detection. Different reasoners support different OWL profiles and have
+ * different performance characteristics.
+ *
+ * @see <a href="https://robot.obolibrary.org/reason">ROBOT Reason Documentation</a>
+ */
+public enum Reasoner {
+
+  /**
+   * ELK reasoner for OWL EL ontologies.
+   *
+   * <p>
+   * Fast reasoner optimized for the OWL EL profile. Suitable for most biomedical ontologies
+   * that use only existential restrictions and conjunctions.
+   */
+  ELK("ELK"),
+
+  /**
+   * HermiT reasoner for full OWL DL ontologies.
+   *
+   * <p>
+   * Complete reasoner supporting the full OWL DL profile, including universal restrictions,
+   * cardinality constraints, and nominals. Slower than ELK but handles more expressive ontologies.
+   */
+  HERMIT("HermiT"),
+
+  /**
+   * JFact reasoner for OWL DL ontologies.
+   *
+   * <p>
+   * Alternative OWL DL reasoner. Supports the same expressivity as HermiT with different
+   * performance characteristics.
+   */
+  JFACT("JFact"),
+
+  /**
+   * Whelk reasoner for OWL EL ontologies.
+   *
+   * <p>
+   * Scala-based EL reasoner. Alternative to ELK for OWL EL profile ontologies.
+   */
+  WHELK("whelk"),
+
+  /**
+   * Structural reasoner using syntactic checks only.
+   *
+   * <p>
+   * Lightweight reasoner that performs structural (syntactic) subsumption checks without
+   * full logical reasoning. Fastest option but may miss logically entailed redundancies.
+   */
+  STRUCTURAL("structural");
+
+  private final String reasonerName;
+
+  Reasoner(String reasonerName) {
+    this.reasonerName = reasonerName;
+  }
+
+  /**
+   * Returns the ROBOT CLI reasoner name.
+   *
+   * @return the reasoner name string (e.g., {@code "ELK"}, {@code "HermiT"})
+   */
+  public String getReasonerName() {
+    return reasonerName;
+  }
+}

--- a/src/main/java/edu/stanford/protege/robot/command/reduce/ReduceFlags.java
+++ b/src/main/java/edu/stanford/protege/robot/command/reduce/ReduceFlags.java
@@ -1,0 +1,57 @@
+package edu.stanford.protege.robot.command.reduce;
+
+/**
+ * Boolean flags for ROBOT reduce command.
+ *
+ * <p>
+ * These flags control how redundant subClassOf axioms are identified and removed. The reduce
+ * command uses automated reasoning to find axioms that are entailed by other axioms in the
+ * ontology, and removes them to simplify the class hierarchy.
+ */
+public enum ReduceFlags {
+
+  /**
+   * Preserve axioms that have annotations.
+   *
+   * <p>
+   * Generates {@code --preserve-annotated-axioms true}. When specified, subClassOf axioms that
+   * carry annotations (such as provenance or definition source) are retained even if they are
+   * logically redundant.
+   */
+  PRESERVE_ANNOTATED_AXIOMS("--preserve-annotated-axioms"),
+
+  /**
+   * Check only named classes for redundancy.
+   *
+   * <p>
+   * Generates {@code --named-classes-only true}. When specified, restricts redundancy checking
+   * to named classes only, excluding anonymous class expressions from the evaluation.
+   */
+  NAMED_CLASSES_ONLY("--named-classes-only"),
+
+  /**
+   * Include subproperties in redundancy evaluation.
+   *
+   * <p>
+   * Generates {@code --include-subproperties true}. When specified, factors subproperty
+   * relationships into the redundancy evaluation, allowing the reasoner to detect additional
+   * redundant axioms through property hierarchy reasoning.
+   */
+  INCLUDE_SUBPROPERTIES("--include-subproperties"),
+  ;
+
+  private final String flagName;
+
+  ReduceFlags(String flagName) {
+    this.flagName = flagName;
+  }
+
+  /**
+   * Returns the ROBOT CLI flag name.
+   *
+   * @return the flag string (e.g., {@code "--preserve-annotated-axioms"})
+   */
+  public String getFlagName() {
+    return flagName;
+  }
+}

--- a/src/main/java/edu/stanford/protege/robot/command/reduce/RobotReduceCommand.java
+++ b/src/main/java/edu/stanford/protege/robot/command/reduce/RobotReduceCommand.java
@@ -1,0 +1,80 @@
+package edu.stanford.protege.robot.command.reduce;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.collect.ImmutableList;
+import edu.stanford.protege.robot.command.common.Reasoner;
+import edu.stanford.protege.robot.command.RobotCommand;
+import java.util.Arrays;
+import java.util.List;
+import org.obolibrary.robot.Command;
+import org.obolibrary.robot.ReduceCommand;
+
+/**
+ * ROBOT reduce command for removing redundant subClassOf axioms using automated reasoning.
+ *
+ * <p>
+ * The reduce command uses a reasoner to identify and remove subClassOf axioms that are already
+ * entailed by other axioms in the ontology. This simplifies the class hierarchy by eliminating
+ * redundant relationships without changing the logical content.
+ *
+ * @param reasoner
+ *          the OWL reasoner to use for entailment checking. Required parameter that determines
+ *          which reasoning engine evaluates axiom redundancy. Available reasoners: {@link
+ *          Reasoner#ELK}, {@link Reasoner#HERMIT}, {@link Reasoner#JFACT},
+ *          {@link Reasoner#WHELK}, {@link Reasoner#STRUCTURAL}.
+ * @param flags
+ *          optional boolean flags for non-default reduction behaviors. Available flags: {@link
+ *          ReduceFlags#PRESERVE_ANNOTATED_AXIOMS}, {@link ReduceFlags#NAMED_CLASSES_ONLY},
+ *          {@link ReduceFlags#INCLUDE_SUBPROPERTIES}. If not specified, ROBOT defaults are used.
+ * 
+ * @see <a href="https://robot.obolibrary.org/reduce">ROBOT Reduce Documentation</a>
+ */
+@JsonTypeName("ReduceCommand")
+public record RobotReduceCommand(Reasoner reasoner, ReduceFlags... flags)
+    implements RobotCommand {
+
+  /**
+   * Converts this reduce command to ROBOT command-line arguments.
+   *
+   * <p>
+   * Always emits {@code --reasoner <name>} first, followed by any specified flags with value
+   * {@code "true"}.
+   *
+   * @return immutable list of command-line arguments for ROBOT reduce
+   */
+  @Override
+  public List<String> getArgs() {
+    var args = ImmutableList.<String>builder();
+
+    // Always add required reasoner argument
+    args.add("--reasoner");
+    args.add(reasoner.getReasonerName());
+
+    // Add flags (each flag enables a non-default behavior)
+    List<ReduceFlags> flagsList = Arrays.asList(flags);
+    if (flagsList.contains(ReduceFlags.PRESERVE_ANNOTATED_AXIOMS)) {
+      args.add(ReduceFlags.PRESERVE_ANNOTATED_AXIOMS.getFlagName());
+      args.add("true");
+    }
+    if (flagsList.contains(ReduceFlags.NAMED_CLASSES_ONLY)) {
+      args.add(ReduceFlags.NAMED_CLASSES_ONLY.getFlagName());
+      args.add("true");
+    }
+    if (flagsList.contains(ReduceFlags.INCLUDE_SUBPROPERTIES)) {
+      args.add(ReduceFlags.INCLUDE_SUBPROPERTIES.getFlagName());
+      args.add("true");
+    }
+
+    return args.build();
+  }
+
+  /**
+   * Returns the ROBOT ReduceCommand instance for execution.
+   *
+   * @return a new ReduceCommand instance
+   */
+  @Override
+  public Command getCommand() {
+    return new ReduceCommand();
+  }
+}

--- a/src/test/java/edu/stanford/protege/robot/command/reduce/RobotReduceCommandTest.java
+++ b/src/test/java/edu/stanford/protege/robot/command/reduce/RobotReduceCommandTest.java
@@ -1,0 +1,359 @@
+package edu.stanford.protege.robot.command.reduce;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import edu.stanford.protege.robot.command.common.Reasoner;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.obolibrary.robot.ReduceCommand;
+
+class RobotReduceCommandTest {
+
+  @Nested
+  class GetCommand {
+
+    @Test
+    void shouldReturnReduceCommandInstance() {
+      var command = new RobotReduceCommand(Reasoner.ELK);
+
+      var result = command.getCommand();
+
+      assertThat(result).isNotNull().isInstanceOf(ReduceCommand.class);
+    }
+  }
+
+  @Nested
+  class GetArgsWithNoFlags {
+
+    @Test
+    void shouldReturnReasonerArgOnly() {
+      var command = new RobotReduceCommand(Reasoner.ELK);
+
+      var args = command.getArgs();
+
+      assertThat(args).containsExactly("--reasoner", "ELK");
+    }
+
+    @Test
+    void shouldUseDefaultBehaviorWhenNoFlags() {
+      // Default behavior:
+      // - preserve-annotated-axioms: false (remove redundant axioms even if annotated)
+      // - named-classes-only: false (check all classes including anonymous)
+      // - include-subproperties: false (do not factor subproperties)
+      var command = new RobotReduceCommand(Reasoner.ELK);
+
+      var args = command.getArgs();
+
+      assertThat(args).containsExactly("--reasoner", "ELK");
+    }
+  }
+
+  @Nested
+  class GetArgsWithDifferentReasoners {
+
+    @Test
+    void shouldUseElkReasoner() {
+      var command = new RobotReduceCommand(Reasoner.ELK);
+
+      var args = command.getArgs();
+
+      assertThat(args).containsExactly("--reasoner", "ELK");
+    }
+
+    @Test
+    void shouldUseHermitReasoner() {
+      var command = new RobotReduceCommand(Reasoner.HERMIT);
+
+      var args = command.getArgs();
+
+      assertThat(args).containsExactly("--reasoner", "HermiT");
+    }
+
+    @Test
+    void shouldUseJFactReasoner() {
+      var command = new RobotReduceCommand(Reasoner.JFACT);
+
+      var args = command.getArgs();
+
+      assertThat(args).containsExactly("--reasoner", "JFact");
+    }
+
+    @Test
+    void shouldUseWhelkReasoner() {
+      var command = new RobotReduceCommand(Reasoner.WHELK);
+
+      var args = command.getArgs();
+
+      assertThat(args).containsExactly("--reasoner", "whelk");
+    }
+
+    @Test
+    void shouldUseStructuralReasoner() {
+      var command = new RobotReduceCommand(Reasoner.STRUCTURAL);
+
+      var args = command.getArgs();
+
+      assertThat(args).containsExactly("--reasoner", "structural");
+    }
+  }
+
+  @Nested
+  class GetArgsWithSingleFlag {
+
+    @Test
+    void shouldIncludePreserveAnnotatedAxiomsFlag() {
+      var command = new RobotReduceCommand(
+          Reasoner.ELK,
+          ReduceFlags.PRESERVE_ANNOTATED_AXIOMS);
+
+      var args = command.getArgs();
+
+      assertThat(args)
+          .containsExactly(
+              "--reasoner", "ELK",
+              "--preserve-annotated-axioms", "true");
+    }
+
+    @Test
+    void shouldIncludeNamedClassesOnlyFlag() {
+      var command = new RobotReduceCommand(
+          Reasoner.ELK,
+          ReduceFlags.NAMED_CLASSES_ONLY);
+
+      var args = command.getArgs();
+
+      assertThat(args)
+          .containsExactly(
+              "--reasoner", "ELK",
+              "--named-classes-only", "true");
+    }
+
+    @Test
+    void shouldIncludeSubpropertiesFlag() {
+      var command = new RobotReduceCommand(
+          Reasoner.ELK,
+          ReduceFlags.INCLUDE_SUBPROPERTIES);
+
+      var args = command.getArgs();
+
+      assertThat(args)
+          .containsExactly(
+              "--reasoner", "ELK",
+              "--include-subproperties", "true");
+    }
+  }
+
+  @Nested
+  class GetArgsWithMultipleFlags {
+
+    @Test
+    void shouldCombinePreserveAnnotatedAxiomsAndNamedClassesOnly() {
+      var command = new RobotReduceCommand(
+          Reasoner.ELK,
+          ReduceFlags.PRESERVE_ANNOTATED_AXIOMS,
+          ReduceFlags.NAMED_CLASSES_ONLY);
+
+      var args = command.getArgs();
+
+      assertThat(args)
+          .containsExactly(
+              "--reasoner", "ELK",
+              "--preserve-annotated-axioms", "true",
+              "--named-classes-only", "true");
+    }
+
+    @Test
+    void shouldCombinePreserveAnnotatedAxiomsAndIncludeSubproperties() {
+      var command = new RobotReduceCommand(
+          Reasoner.ELK,
+          ReduceFlags.PRESERVE_ANNOTATED_AXIOMS,
+          ReduceFlags.INCLUDE_SUBPROPERTIES);
+
+      var args = command.getArgs();
+
+      assertThat(args)
+          .containsExactly(
+              "--reasoner", "ELK",
+              "--preserve-annotated-axioms", "true",
+              "--include-subproperties", "true");
+    }
+
+    @Test
+    void shouldCombineNamedClassesOnlyAndIncludeSubproperties() {
+      var command = new RobotReduceCommand(
+          Reasoner.ELK,
+          ReduceFlags.NAMED_CLASSES_ONLY,
+          ReduceFlags.INCLUDE_SUBPROPERTIES);
+
+      var args = command.getArgs();
+
+      assertThat(args)
+          .containsExactly(
+              "--reasoner", "ELK",
+              "--named-classes-only", "true",
+              "--include-subproperties", "true");
+    }
+
+    @Test
+    void shouldCombineAllThreeFlags() {
+      var command = new RobotReduceCommand(
+          Reasoner.ELK,
+          ReduceFlags.PRESERVE_ANNOTATED_AXIOMS,
+          ReduceFlags.NAMED_CLASSES_ONLY,
+          ReduceFlags.INCLUDE_SUBPROPERTIES);
+
+      var args = command.getArgs();
+
+      assertThat(args)
+          .containsExactly(
+              "--reasoner", "ELK",
+              "--preserve-annotated-axioms", "true",
+              "--named-classes-only", "true",
+              "--include-subproperties", "true");
+    }
+  }
+
+  @Nested
+  class GetArgsArray {
+
+    @Test
+    void shouldConvertToArrayWithReasonerOnly() {
+      var command = new RobotReduceCommand(Reasoner.ELK);
+
+      var argsArray = command.getArgsArray();
+
+      assertThat(argsArray).containsExactly("--reasoner", "ELK");
+    }
+
+    @Test
+    void shouldConvertToArrayWithSingleFlag() {
+      var command = new RobotReduceCommand(
+          Reasoner.ELK,
+          ReduceFlags.PRESERVE_ANNOTATED_AXIOMS);
+
+      var argsArray = command.getArgsArray();
+
+      assertThat(argsArray)
+          .containsExactly(
+              "--reasoner", "ELK",
+              "--preserve-annotated-axioms", "true");
+    }
+
+    @Test
+    void shouldConvertToArrayWithMultipleFlags() {
+      var command = new RobotReduceCommand(
+          Reasoner.ELK,
+          ReduceFlags.PRESERVE_ANNOTATED_AXIOMS,
+          ReduceFlags.NAMED_CLASSES_ONLY,
+          ReduceFlags.INCLUDE_SUBPROPERTIES);
+
+      var argsArray = command.getArgsArray();
+
+      assertThat(argsArray)
+          .containsExactly(
+              "--reasoner", "ELK",
+              "--preserve-annotated-axioms", "true",
+              "--named-classes-only", "true",
+              "--include-subproperties", "true");
+    }
+  }
+
+  @Nested
+  class Immutability {
+
+    @Test
+    void shouldReturnImmutableList() {
+      var command = new RobotReduceCommand(
+          Reasoner.ELK,
+          ReduceFlags.PRESERVE_ANNOTATED_AXIOMS,
+          ReduceFlags.NAMED_CLASSES_ONLY);
+
+      var args = command.getArgs();
+
+      assertThat(args).isUnmodifiable();
+    }
+
+    @Test
+    void shouldReturnImmutableListWithReasonerOnly() {
+      var command = new RobotReduceCommand(Reasoner.ELK);
+
+      var args = command.getArgs();
+
+      assertThat(args).isUnmodifiable();
+    }
+  }
+
+  @Nested
+  class RealWorldScenarios {
+
+    @Test
+    void shouldHandleBasicReduction() {
+      // Most common use case: basic reduction with ELK reasoner
+      var command = new RobotReduceCommand(Reasoner.ELK);
+
+      var args = command.getArgs();
+
+      assertThat(args).containsExactly("--reasoner", "ELK");
+    }
+
+    @Test
+    void shouldHandlePreservingAnnotations() {
+      // Preserve annotated axioms during reduction
+      var command = new RobotReduceCommand(
+          Reasoner.ELK,
+          ReduceFlags.PRESERVE_ANNOTATED_AXIOMS);
+
+      var args = command.getArgs();
+
+      assertThat(args)
+          .containsExactly(
+              "--reasoner", "ELK",
+              "--preserve-annotated-axioms", "true");
+    }
+
+    @Test
+    void shouldHandleHermitForFullOwl() {
+      // Use HermiT for ontologies requiring full OWL DL reasoning
+      var command = new RobotReduceCommand(Reasoner.HERMIT);
+
+      var args = command.getArgs();
+
+      assertThat(args).containsExactly("--reasoner", "HermiT");
+    }
+
+    @Test
+    void shouldHandleComprehensiveReduction() {
+      // Full reduction with all options enabled
+      var command = new RobotReduceCommand(
+          Reasoner.ELK,
+          ReduceFlags.PRESERVE_ANNOTATED_AXIOMS,
+          ReduceFlags.NAMED_CLASSES_ONLY,
+          ReduceFlags.INCLUDE_SUBPROPERTIES);
+
+      var args = command.getArgs();
+
+      assertThat(args)
+          .containsExactly(
+              "--reasoner", "ELK",
+              "--preserve-annotated-axioms", "true",
+              "--named-classes-only", "true",
+              "--include-subproperties", "true");
+    }
+
+    @Test
+    void shouldHandleRelaxReduceWorkflow() {
+      // Reduce step in a relax-reduce workflow
+      // After relax generates SubClassOf axioms, reduce removes redundant ones
+      var command = new RobotReduceCommand(
+          Reasoner.ELK,
+          ReduceFlags.NAMED_CLASSES_ONLY);
+
+      var args = command.getArgs();
+
+      assertThat(args)
+          .containsExactly(
+              "--reasoner", "ELK",
+              "--named-classes-only", "true");
+    }
+  }
+}


### PR DESCRIPTION
## Summary
  - Add new reduce command handler that removes redundant subClassOf axioms
  using selected resoner

  ## Changes
  - `Reasoner.java` - New enum in `common` package with 5 supported OWL
  reasoners (ELK, HermiT, JFact, whelk, structural)
  - `ReduceFlags.java` - Enum with 3 optional boolean flags
  (preserve-annotated-axioms, named-classes-only, include-subproperties)
  - `RobotReduceCommand.java` - Command record with required `--reasoner`
  parameter and optional flags

 ## Usage

  ```java
  // Basic reduction with ELK reasoner
  var command = new RobotReduceCommand(Reasoner.ELK);
  command.getArgs();  // ["--reasoner", "ELK"]

  // With flags to preserve annotated axioms
  var command = new RobotReduceCommand(
      Reasoner.HERMIT,
      ReduceFlags.PRESERVE_ANNOTATED_AXIOMS,
      ReduceFlags.NAMED_CLASSES_ONLY);
  command.getArgs();  // ["--reasoner", "HermiT", "--preserve-annotated-axioms", "true", "--named-classes-only", "true"]