### PR TITLE
Add pipeline snapshot orchestration and stabilize tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,12 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>edu.stanford.protege</groupId>
+            <artifactId>webprotege-revision-manager</artifactId>
+            <version>0.9.2</version>
+        </dependency>
+
         <!-- MinIO -->
         <dependency>
             <groupId>io.minio</groupId>
@@ -128,6 +134,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
+            <version>2.0.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/edu/stanford/protege/robot/ApplicationBeansConfiguration.java
+++ b/src/main/java/edu/stanford/protege/robot/ApplicationBeansConfiguration.java
@@ -1,7 +1,7 @@
 package edu.stanford.protege.robot;
 
 import edu.stanford.protege.robot.pipeline.PipelineLogger;
-import edu.stanford.protege.robot.service.RobotPipelineExecutor;
+import edu.stanford.protege.robot.service.RobotPipelineOrchestrator;
 import edu.stanford.protege.webprotege.ipc.EventDispatcher;
 import edu.stanford.protege.webprotege.ipc.WebProtegeIpcApplication;
 import org.springframework.context.annotation.Bean;
@@ -13,8 +13,8 @@ import org.springframework.context.annotation.Import;
 public class ApplicationBeansConfiguration {
 
   @Bean
-  ExecuteRobotCommandsHandler createExecuteRobotCommandsHandler(RobotPipelineExecutor executor) {
-    return new ExecuteRobotCommandsHandler(executor);
+  ExecuteRobotCommandsHandler createExecuteRobotCommandsHandler(RobotPipelineOrchestrator orchestrator) {
+    return new ExecuteRobotCommandsHandler(orchestrator);
   }
 
   @Bean

--- a/src/main/java/edu/stanford/protege/robot/pipeline/PipelineLogger.java
+++ b/src/main/java/edu/stanford/protege/robot/pipeline/PipelineLogger.java
@@ -58,6 +58,25 @@ public class PipelineLogger {
         new LoadOntologyFailedEvent(projectId, executionId, pipelineId, EventId.generate(), t.getMessage()));
   }
 
+  public void snapshotOntologyStarted(ProjectId projectId, PipelineExecutionId executionId, PipelineId pipelineId) {
+    logger.info("{} {} {} ROBOT pipeline snapshotting ontology", projectId, executionId, pipelineId);
+    eventDispatcher.dispatchEvent(
+        new SnapshotOntologyStartedEvent(projectId, executionId, pipelineId, EventId.generate()));
+  }
+
+  public void snapshotOntologySucceeded(ProjectId projectId, PipelineExecutionId executionId, PipelineId pipelineId) {
+    logger.info("{} {} {} ROBOT pipeline snapshotting ontology succeeded", projectId, executionId, pipelineId);
+    eventDispatcher.dispatchEvent(
+        new SnapshotOntologySucceededEvent(projectId, executionId, pipelineId, EventId.generate()));
+  }
+
+  public void snapshotOntologyFailed(ProjectId projectId, PipelineExecutionId executionId, PipelineId pipelineId,
+      Throwable t) {
+    logger.error("{} {} {} ROBOT pipeline snapshotting ontology failed", projectId, executionId, pipelineId, t);
+    eventDispatcher.dispatchEvent(
+        new SnapshotOntologyFailedEvent(projectId, executionId, pipelineId, EventId.generate(), t.getMessage()));
+  }
+
   public void pipelineStageStarted(ProjectId projectId, PipelineExecutionId executionId, PipelineId pipelineId,
       Command command) {
     logger.info("{} {} {} ROBOT pipeline stage started: {}", projectId, executionId, pipelineId, command.getName());

--- a/src/main/java/edu/stanford/protege/robot/pipeline/PipelinePreparationStatus.java
+++ b/src/main/java/edu/stanford/protege/robot/pipeline/PipelinePreparationStatus.java
@@ -1,0 +1,46 @@
+package edu.stanford.protege.robot.pipeline;
+
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public record PipelinePreparationStatus(
+    @Nonnull StageStatus status,
+    @Nullable String message) {
+
+  public PipelinePreparationStatus {
+    Objects.requireNonNull(status, "status cannot be null");
+  }
+
+  public static PipelinePreparationStatus waiting(@Nullable String message) {
+    return new PipelinePreparationStatus(StageStatus.WAITING, message);
+  }
+
+  public static PipelinePreparationStatus running(@Nullable String message) {
+    return new PipelinePreparationStatus(StageStatus.RUNNING, message);
+  }
+
+  public static PipelinePreparationStatus finishedWithSuccess(@Nullable String message) {
+    return new PipelinePreparationStatus(StageStatus.FINISHED_WITH_SUCCESS, message);
+  }
+
+  public static PipelinePreparationStatus finishedWithError(@Nullable String message) {
+    return new PipelinePreparationStatus(StageStatus.FINISHED_WITH_ERROR, message);
+  }
+
+  public boolean isWaiting() {
+    return status == StageStatus.WAITING;
+  }
+
+  public boolean isRunning() {
+    return status == StageStatus.RUNNING;
+  }
+
+  public boolean isSuccessful() {
+    return status == StageStatus.FINISHED_WITH_SUCCESS;
+  }
+
+  public boolean isFailed() {
+    return status == StageStatus.FINISHED_WITH_ERROR;
+  }
+}

--- a/src/main/java/edu/stanford/protege/robot/pipeline/event/SnapshotOntologyEvent.java
+++ b/src/main/java/edu/stanford/protege/robot/pipeline/event/SnapshotOntologyEvent.java
@@ -1,0 +1,11 @@
+package edu.stanford.protege.robot.pipeline.event;
+
+import edu.stanford.protege.robot.pipeline.PipelineExecutionId;
+import edu.stanford.protege.webprotege.common.ProjectEvent;
+
+sealed interface SnapshotOntologyEvent
+    extends
+      ProjectEvent permits SnapshotOntologyStartedEvent, SnapshotOntologySucceededEvent, SnapshotOntologyFailedEvent {
+
+  PipelineExecutionId executionId();
+}

--- a/src/main/java/edu/stanford/protege/robot/pipeline/event/SnapshotOntologyFailedEvent.java
+++ b/src/main/java/edu/stanford/protege/robot/pipeline/event/SnapshotOntologyFailedEvent.java
@@ -1,0 +1,26 @@
+package edu.stanford.protege.robot.pipeline.event;
+
+import static edu.stanford.protege.robot.pipeline.event.SnapshotOntologyFailedEvent.CHANNEL;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import edu.stanford.protege.robot.pipeline.PipelineExecutionId;
+import edu.stanford.protege.robot.pipeline.PipelineId;
+import edu.stanford.protege.webprotege.common.EventId;
+import edu.stanford.protege.webprotege.common.ProjectId;
+import javax.annotation.Nonnull;
+
+@JsonTypeName(CHANNEL)
+public record SnapshotOntologyFailedEvent(
+    @Nonnull ProjectId projectId,
+    @Nonnull PipelineExecutionId executionId,
+    @Nonnull PipelineId pipelineId,
+    @Nonnull EventId eventId,
+    @Nonnull String errorMessage) implements SnapshotOntologyEvent {
+
+  public static final String CHANNEL = "webprotege.events.robot.SnapshotOntologyFailed";
+
+  @Override
+  public String getChannel() {
+    return CHANNEL;
+  }
+}

--- a/src/main/java/edu/stanford/protege/robot/pipeline/event/SnapshotOntologyStartedEvent.java
+++ b/src/main/java/edu/stanford/protege/robot/pipeline/event/SnapshotOntologyStartedEvent.java
@@ -1,0 +1,25 @@
+package edu.stanford.protege.robot.pipeline.event;
+
+import static edu.stanford.protege.robot.pipeline.event.SnapshotOntologyStartedEvent.CHANNEL;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import edu.stanford.protege.robot.pipeline.PipelineExecutionId;
+import edu.stanford.protege.robot.pipeline.PipelineId;
+import edu.stanford.protege.webprotege.common.EventId;
+import edu.stanford.protege.webprotege.common.ProjectId;
+import javax.annotation.Nonnull;
+
+@JsonTypeName(CHANNEL)
+public record SnapshotOntologyStartedEvent(
+    @Nonnull ProjectId projectId,
+    @Nonnull PipelineExecutionId executionId,
+    @Nonnull PipelineId pipelineId,
+    @Nonnull EventId eventId) implements SnapshotOntologyEvent {
+
+  public static final String CHANNEL = "webprotege.events.robot.SnapshotOntologyStarted";
+
+  @Override
+  public String getChannel() {
+    return CHANNEL;
+  }
+}

--- a/src/main/java/edu/stanford/protege/robot/pipeline/event/SnapshotOntologySucceededEvent.java
+++ b/src/main/java/edu/stanford/protege/robot/pipeline/event/SnapshotOntologySucceededEvent.java
@@ -1,0 +1,25 @@
+package edu.stanford.protege.robot.pipeline.event;
+
+import static edu.stanford.protege.robot.pipeline.event.SnapshotOntologySucceededEvent.CHANNEL;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import edu.stanford.protege.robot.pipeline.PipelineExecutionId;
+import edu.stanford.protege.robot.pipeline.PipelineId;
+import edu.stanford.protege.webprotege.common.EventId;
+import edu.stanford.protege.webprotege.common.ProjectId;
+import javax.annotation.Nonnull;
+
+@JsonTypeName(CHANNEL)
+public record SnapshotOntologySucceededEvent(
+    @Nonnull ProjectId projectId,
+    @Nonnull PipelineExecutionId executionId,
+    @Nonnull PipelineId pipelineId,
+    @Nonnull EventId eventId) implements SnapshotOntologyEvent {
+
+  public static final String CHANNEL = "webprotege.events.robot.SnapshotOntologySucceeded";
+
+  @Override
+  public String getChannel() {
+    return CHANNEL;
+  }
+}

--- a/src/main/java/edu/stanford/protege/robot/service/RobotPipelineOrchestrator.java
+++ b/src/main/java/edu/stanford/protege/robot/service/RobotPipelineOrchestrator.java
@@ -1,0 +1,163 @@
+package edu.stanford.protege.robot.service;
+
+import edu.stanford.protege.robot.pipeline.*;
+import edu.stanford.protege.robot.service.snapshot.ProjectOntologySnapshotProvider;
+import edu.stanford.protege.webprotege.common.ProjectId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.Nonnull;
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+@Service
+/**
+ * Orchestrates asynchronous pipeline execution by first creating a project ontology snapshot and
+ * then delegating to the {@link RobotPipelineExecutor}.
+ *
+ * <p>
+ * The orchestrator is responsible for preparation status updates and snapshot lifecycle events so
+ * that clients can display progress before pipeline stages begin.
+ */
+public class RobotPipelineOrchestrator {
+
+    private static final Logger logger = LoggerFactory.getLogger(RobotPipelineOrchestrator.class);
+
+    private final RobotPipelineExecutor executor;
+
+    private final ProjectOntologySnapshotProvider snapshotProvider;
+
+    private final PipelineStatusRepository pipelineStatusRepository;
+
+    private final PipelineLogger pipelineLogger;
+
+    private final Executor pipelineExecutor;
+
+    public RobotPipelineOrchestrator(RobotPipelineExecutor executor,
+                                     ProjectOntologySnapshotProvider snapshotProvider,
+                                     PipelineStatusRepository pipelineStatusRepository,
+                                     PipelineLogger pipelineLogger,
+                                     @Qualifier("robotPipelineExecutor") Executor pipelineExecutor) {
+        this.executor = executor;
+        this.snapshotProvider = snapshotProvider;
+        this.pipelineStatusRepository = pipelineStatusRepository;
+        this.pipelineLogger = pipelineLogger;
+        this.pipelineExecutor = pipelineExecutor;
+    }
+
+  /**
+   * Starts an asynchronous pipeline execution for the supplied project and pipeline.
+   *
+   * <p>
+   * This method returns immediately after creating the execution id and persisting an initial
+   * pipeline status. Snapshot creation and pipeline execution occur off-thread.
+   *
+   * @param projectId
+   *          the project whose ontology will be snapshotted
+   * @param pipeline
+   *          the pipeline to execute
+   * @return the generated pipeline execution id
+   */
+  public PipelineExecutionId executeAsync(@Nonnull ProjectId projectId, @Nonnull RobotPipeline pipeline) {
+        var executionId = PipelineExecutionId.generate();
+        // Seed pipeline status immediately so clients can render "preparing snapshot" before work starts.
+        var status = PipelineStatus.createWithPreparationStatus(
+                executionId,
+                pipeline.pipelineId(),
+                Instant.now(),
+                pipeline,
+                PipelinePreparationStatus.waiting("Preparing ontology snapshot"));
+        pipelineStatusRepository.saveStatus(status);
+
+        // Fire-and-forget: snapshot + pipeline execute off-thread to keep the handler non-blocking.
+        CompletableFuture.runAsync(() -> executeAsyncInternal(projectId, executionId, pipeline), pipelineExecutor);
+        return executionId;
+    }
+
+  /**
+   * Runs snapshot creation and pipeline execution in the background for a given execution id.
+   *
+   * @param projectId
+   *          the project whose ontology will be snapshotted
+   * @param executionId
+   *          the execution id for this run
+   * @param pipeline
+   *          the pipeline to execute
+   */
+  private void executeAsyncInternal(ProjectId projectId, PipelineExecutionId executionId, RobotPipeline pipeline) {
+        try {
+            // Snapshotting is an explicit preparation phase with its own events/status updates.
+            updatePreparationStatus(executionId, pipeline, PipelinePreparationStatus.running("Preparing ontology snapshot"));
+            pipelineLogger.snapshotOntologyStarted(projectId, executionId, pipeline.pipelineId());
+            var snapshot = snapshotProvider.createSnapshot(projectId);
+            var ontology = snapshot.ontology();
+            var revisionNumber = snapshot.revisionNumber();
+            updatePreparationStatus(executionId, pipeline,
+                    PipelinePreparationStatus.finishedWithSuccess("Ontology snapshot ready"));
+            pipelineLogger.snapshotOntologySucceeded(projectId, executionId, pipeline.pipelineId());
+
+            // Hand off to the executor once the ontology snapshot is ready.
+            executor.executePipeline(projectId, executionId, ontology, revisionNumber, pipeline);
+            logger.info("{} {} Pipeline execution finished successfully", projectId, executionId);
+        } catch(Exception e) {
+            logger.info("{} {} Pipeline execution failed: {}", projectId, executionId, e.getMessage());
+            // If snapshotting fails, finalize status immediately (no pipeline stages will run).
+            updatePreparationStatusWithEndTime(executionId, pipeline,
+                    PipelinePreparationStatus.finishedWithError("Snapshot failed: " + e.getMessage()));
+            pipelineLogger.snapshotOntologyFailed(projectId, executionId, pipeline.pipelineId(), e);
+            pipelineLogger.pipelineExecutionFinishedWithError(projectId, executionId, pipeline.pipelineId(), e);
+        }
+  }
+
+  /**
+   * Persists the preparation status for a pipeline execution, recreating the status if necessary.
+   *
+   * @param executionId
+   *          the pipeline execution id
+   * @param pipeline
+   *          the pipeline definition
+   * @param preparationStatus
+   *          the new preparation status to save
+   */
+  private void updatePreparationStatus(PipelineExecutionId executionId, RobotPipeline pipeline,
+      PipelinePreparationStatus preparationStatus) {
+        // Defensive: recreate status if it was evicted or missing in storage.
+        var status = pipelineStatusRepository.findStatus(executionId)
+                .orElseGet(() -> PipelineStatus.createWithPreparationStatus(
+                        executionId,
+                        pipeline.pipelineId(),
+                        Instant.now(),
+                        pipeline,
+                        preparationStatus));
+        var updated = PipelineStatus.withPreparationStatus(status, preparationStatus);
+        pipelineStatusRepository.saveStatus(updated);
+  }
+
+  /**
+   * Persists a preparation status update and marks the pipeline execution as ended.
+   *
+   * @param executionId
+   *          the pipeline execution id
+   * @param pipeline
+   *          the pipeline definition
+   * @param preparationStatus
+   *          the terminal preparation status to save
+   */
+  private void updatePreparationStatusWithEndTime(PipelineExecutionId executionId, RobotPipeline pipeline,
+      PipelinePreparationStatus preparationStatus) {
+        // Terminal update for snapshot failures; ensures the pipeline isn't reported as running.
+        var status = pipelineStatusRepository.findStatus(executionId)
+                .orElseGet(() -> PipelineStatus.createWithPreparationStatus(
+                        executionId,
+                        pipeline.pipelineId(),
+                        Instant.now(),
+                        pipeline,
+                        preparationStatus));
+        var updated = PipelineStatus.withPreparationStatus(status, preparationStatus);
+        updated = PipelineStatus.withEndTime(updated, Instant.now());
+        pipelineStatusRepository.saveStatus(updated);
+    }
+}

--- a/src/main/java/edu/stanford/protege/robot/service/config/RevisionManagerConfiguration.java
+++ b/src/main/java/edu/stanford/protege/robot/service/config/RevisionManagerConfiguration.java
@@ -1,0 +1,56 @@
+package edu.stanford.protege.robot.service.config;
+
+import edu.stanford.protege.webprotege.revision.ChangeHistoryFileFactory;
+import edu.stanford.protege.webprotege.revision.HeadRevisionNumberFinder;
+import edu.stanford.protege.webprotege.revision.OntologyChangeRecordTranslator;
+import edu.stanford.protege.webprotege.revision.OntologyChangeRecordTranslatorImpl;
+import edu.stanford.protege.webprotege.revision.ProjectDirectoryFactory;
+import edu.stanford.protege.webprotege.revision.RevisionManagerFactory;
+import edu.stanford.protege.webprotege.revision.RevisionStoreFactory;
+import java.io.File;
+import org.semanticweb.owlapi.model.OWLDataFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import uk.ac.manchester.cs.owl.owlapi.OWLDataFactoryImpl;
+
+@Configuration
+public class RevisionManagerConfiguration {
+
+  @Bean
+  OWLDataFactory dataFactory() {
+    return new OWLDataFactoryImpl();
+  }
+
+  @Bean
+  OntologyChangeRecordTranslator ontologyChangeRecordTranslator() {
+    return new OntologyChangeRecordTranslatorImpl();
+  }
+
+  @Bean
+  ProjectDirectoryFactory projectDirectoryFactory(@Value("${webprotege.directories.data}") File dataDirectory) {
+    return new ProjectDirectoryFactory(dataDirectory);
+  }
+
+  @Bean
+  ChangeHistoryFileFactory changeHistoryFileFactory(ProjectDirectoryFactory projectDirectoryFactory) {
+    return new ChangeHistoryFileFactory(projectDirectoryFactory);
+  }
+
+  @Bean
+  RevisionStoreFactory revisionStoreFactory(ChangeHistoryFileFactory p1,
+      OWLDataFactory p2,
+      OntologyChangeRecordTranslator p3) {
+    return new RevisionStoreFactory(p1, p2, p3);
+  }
+
+  @Bean
+  RevisionManagerFactory revisionManagerFactory(RevisionStoreFactory revisionStoreFactory) {
+    return new RevisionManagerFactory(revisionStoreFactory);
+  }
+
+  @Bean
+  HeadRevisionNumberFinder headRevisionNumberFinder(ChangeHistoryFileFactory changeHistoryFileFactory) {
+    return new HeadRevisionNumberFinder(changeHistoryFileFactory);
+  }
+}

--- a/src/main/java/edu/stanford/protege/robot/service/config/RobotPipelineExecutorConfiguration.java
+++ b/src/main/java/edu/stanford/protege/robot/service/config/RobotPipelineExecutorConfiguration.java
@@ -1,0 +1,25 @@
+package edu.stanford.protege.robot.service.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableConfigurationProperties(RobotPipelineExecutorProperties.class)
+public class RobotPipelineExecutorConfiguration {
+
+  @Bean
+  Executor robotPipelineExecutor(RobotPipelineExecutorProperties properties) {
+    var executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(properties.getCorePoolSize());
+    executor.setMaxPoolSize(properties.getMaxPoolSize());
+    executor.setQueueCapacity(properties.getQueueCapacity());
+    executor.setThreadNamePrefix(properties.getThreadNamePrefix());
+    executor.setWaitForTasksToCompleteOnShutdown(properties.isWaitForTasksToCompleteOnShutdown());
+    executor.setAwaitTerminationSeconds(properties.getAwaitTerminationSeconds());
+    executor.initialize();
+    return executor;
+  }
+}

--- a/src/main/java/edu/stanford/protege/robot/service/config/RobotPipelineExecutorProperties.java
+++ b/src/main/java/edu/stanford/protege/robot/service/config/RobotPipelineExecutorProperties.java
@@ -1,0 +1,62 @@
+package edu.stanford.protege.robot.service.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "webprotege.robot.executor")
+public class RobotPipelineExecutorProperties {
+
+  private int corePoolSize = 2;
+  private int maxPoolSize = 4;
+  private int queueCapacity = 100;
+  private String threadNamePrefix = "robot-pipeline-";
+  private boolean waitForTasksToCompleteOnShutdown = true;
+  private int awaitTerminationSeconds = 60;
+
+  public int getCorePoolSize() {
+    return corePoolSize;
+  }
+
+  public void setCorePoolSize(int corePoolSize) {
+    this.corePoolSize = corePoolSize;
+  }
+
+  public int getMaxPoolSize() {
+    return maxPoolSize;
+  }
+
+  public void setMaxPoolSize(int maxPoolSize) {
+    this.maxPoolSize = maxPoolSize;
+  }
+
+  public int getQueueCapacity() {
+    return queueCapacity;
+  }
+
+  public void setQueueCapacity(int queueCapacity) {
+    this.queueCapacity = queueCapacity;
+  }
+
+  public String getThreadNamePrefix() {
+    return threadNamePrefix;
+  }
+
+  public void setThreadNamePrefix(String threadNamePrefix) {
+    this.threadNamePrefix = threadNamePrefix;
+  }
+
+  public boolean isWaitForTasksToCompleteOnShutdown() {
+    return waitForTasksToCompleteOnShutdown;
+  }
+
+  public void setWaitForTasksToCompleteOnShutdown(boolean waitForTasksToCompleteOnShutdown) {
+    this.waitForTasksToCompleteOnShutdown = waitForTasksToCompleteOnShutdown;
+  }
+
+  public int getAwaitTerminationSeconds() {
+    return awaitTerminationSeconds;
+  }
+
+  public void setAwaitTerminationSeconds(int awaitTerminationSeconds) {
+    this.awaitTerminationSeconds = awaitTerminationSeconds;
+  }
+}

--- a/src/main/java/edu/stanford/protege/robot/service/snapshot/ProjectOntologySnapshot.java
+++ b/src/main/java/edu/stanford/protege/robot/service/snapshot/ProjectOntologySnapshot.java
@@ -1,0 +1,5 @@
+package edu.stanford.protege.robot.service.snapshot;
+
+import org.semanticweb.owlapi.model.OWLOntology;
+
+public record ProjectOntologySnapshot(OWLOntology ontology, long revisionNumber) {}

--- a/src/main/java/edu/stanford/protege/robot/service/snapshot/ProjectOntologySnapshotProvider.java
+++ b/src/main/java/edu/stanford/protege/robot/service/snapshot/ProjectOntologySnapshotProvider.java
@@ -1,0 +1,103 @@
+package edu.stanford.protege.robot.service.snapshot;
+
+import edu.stanford.protege.robot.service.exception.RobotServiceRuntimeException;
+import edu.stanford.protege.webprotege.common.ProjectId;
+import edu.stanford.protege.webprotege.revision.ChangeHistoryFileFactory;
+import edu.stanford.protege.webprotege.revision.HeadRevisionNumberFinder;
+import edu.stanford.protege.webprotege.revision.RevisionManager;
+import edu.stanford.protege.webprotege.revision.RevisionManagerFactory;
+import edu.stanford.protege.webprotege.revision.RevisionNumber;
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ProjectOntologySnapshotProvider {
+
+  private static final Logger logger = LoggerFactory.getLogger(ProjectOntologySnapshotProvider.class);
+
+  private static final int MAX_LOAD_ATTEMPTS = 3;
+  private static final long LOAD_RETRY_DELAY_MS = 250;
+
+  private final RevisionManagerFactory revisionManagerFactory;
+  private final HeadRevisionNumberFinder headRevisionNumberFinder;
+  private final ChangeHistoryFileFactory changeHistoryFileFactory;
+
+  public ProjectOntologySnapshotProvider(@Nonnull RevisionManagerFactory revisionManagerFactory,
+      @Nonnull HeadRevisionNumberFinder headRevisionNumberFinder,
+      @Nonnull ChangeHistoryFileFactory changeHistoryFileFactory) {
+    this.revisionManagerFactory = revisionManagerFactory;
+    this.headRevisionNumberFinder = headRevisionNumberFinder;
+    this.changeHistoryFileFactory = changeHistoryFileFactory;
+  }
+
+  public ProjectOntologySnapshot createSnapshot(@Nonnull ProjectId projectId) {
+    var changeHistoryFile = changeHistoryFileFactory.getChangeHistoryFile(projectId);
+    if (!changeHistoryFile.exists()) {
+      throw new RobotServiceRuntimeException("Change history file not found for project " + projectId
+                                             + " at " + changeHistoryFile.getAbsolutePath());
+    }
+
+    var revisionManager = loadRevisionManagerWithRetry(projectId);
+    var revisionNumber = revisionManager.getCurrentRevision();
+    var ontologyManager = revisionManager.getOntologyManagerForRevision(revisionNumber);
+    var ontology = selectOntology(ontologyManager)
+        .orElseThrow(() -> new RobotServiceRuntimeException("No ontology found after loading revisions for "
+            + projectId));
+    return new ProjectOntologySnapshot(ontology, revisionNumber.getValue());
+  }
+
+  private RevisionManager loadRevisionManagerWithRetry(ProjectId projectId) {
+    RevisionManager revisionManager = null;
+    RevisionNumber headRevision = null;
+
+    for (int attempt = 1; attempt <= MAX_LOAD_ATTEMPTS; attempt++) {
+      revisionManager = revisionManagerFactory.createRevisionManager(projectId);
+      var currentRevision = revisionManager.getCurrentRevision();
+
+      try {
+        headRevision = headRevisionNumberFinder.getHeadRevisionNumber(projectId);
+      } catch (IOException e) {
+        logger.warn("{} Unable to read head revision number: {}", projectId, e.getMessage());
+      }
+
+      if (headRevision == null || currentRevision.compareTo(headRevision) >= 0) {
+        return revisionManager;
+      }
+
+      logger.warn("{} Loaded revision {} but head appears to be {}. Retrying load (attempt {}/{})",
+          projectId, currentRevision.getValue(), headRevision.getValue(), attempt, MAX_LOAD_ATTEMPTS);
+      sleepBeforeRetry();
+    }
+
+    logger.warn("{} Proceeding with revision {} (head was {}) after retries",
+        projectId,
+        revisionManager.getCurrentRevision().getValue(),
+        headRevision == null ? "unknown" : headRevision.getValue());
+    return revisionManager;
+  }
+
+  private void sleepBeforeRetry() {
+    try {
+      Thread.sleep(LOAD_RETRY_DELAY_MS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  private Optional<OWLOntology> selectOntology(OWLOntologyManager ontologyManager) {
+    if (ontologyManager.getOntologies().isEmpty()) {
+      return Optional.empty();
+    }
+    return ontologyManager.getOntologies().stream()
+        .sorted(Comparator.comparing(o -> o.getOntologyID().getOntologyIRI().isPresent()))
+        .findFirst();
+  }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,8 @@ spring:
       database: webprotege
       auto-index-creation: true
 webprotege:
+  directories:
+    data: ${WEBPROTEGE_DATA_DIR}
   rabbitmq:
     requestqueue: webprotege-robot-queue
     responsequeue: webprotege-robot-response-queue
@@ -22,3 +24,11 @@ webprotege:
     end-point: http://localhost:9000
     secret-key: webprotege
     robot-output-documents-bucket-name: webprotege-robot-output-documents
+  robot:
+    executor:
+      core-pool-size: 2
+      max-pool-size: 4
+      queue-capacity: 100
+      thread-name-prefix: robot-pipeline-
+      wait-for-tasks-to-complete-on-shutdown: true
+      await-termination-seconds: 60

--- a/src/test/java/edu/stanford/protege/robot/pipeline/PipelineStatusRepositoryTest.java
+++ b/src/test/java/edu/stanford/protege/robot/pipeline/PipelineStatusRepositoryTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import edu.stanford.protege.robot.MongoTestExtension;
 import edu.stanford.protege.robot.command.annotate.PlainAnnotation;
 import edu.stanford.protege.robot.command.annotate.RobotAnnotateCommand;
 import edu.stanford.protege.robot.config.TestMongoConfiguration;
@@ -14,22 +13,34 @@ import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.semanticweb.owlapi.model.IRI;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.boot.test.autoconfigure.json.AutoConfigureJson;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
- * Integration tests for {@link PipelineStatusRepository} using MongoTestExtension.
+ * Integration tests for {@link PipelineStatusRepository} using Testcontainers.
  */
 @DataMongoTest
 @AutoConfigureJson
-@ExtendWith({MongoTestExtension.class})
+@Testcontainers
 @Import({JacksonConfiguration.class, TestMongoConfiguration.class})
 class PipelineStatusRepositoryTest {
+
+  @Container
+  static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:7.0");
+
+  @DynamicPropertySource
+  static void setProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
+  }
 
   @Autowired
   private MongoTemplate mongoTemplate;

--- a/src/test/java/edu/stanford/protege/robot/pipeline/PipelineStatusTest.java
+++ b/src/test/java/edu/stanford/protege/robot/pipeline/PipelineStatusTest.java
@@ -1,0 +1,48 @@
+package edu.stanford.protege.robot.pipeline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import edu.stanford.protege.robot.command.RobotCommand;
+import edu.stanford.protege.webprotege.common.ProjectId;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PipelineStatusTest {
+
+  private RobotPipeline pipelineWithSingleStage() {
+    RobotCommand command = mock(RobotCommand.class);
+    var stage = new RobotPipelineStage(PipelineStageId.generate(), null, null, command, null);
+    return new RobotPipeline(ProjectId.generate(), PipelineId.generate(), null, null, List.of(stage));
+  }
+
+  @Test
+  void isRunning_trueWhenPreparationWaiting() {
+    var pipeline = pipelineWithSingleStage();
+    var status = PipelineStatus.createWithPreparationStatus(PipelineExecutionId.generate(), pipeline.pipelineId(),
+        Instant.now(), pipeline, PipelinePreparationStatus.waiting("prepping"));
+
+    assertThat(status.isRunning()).isTrue();
+  }
+
+  @Test
+  void isSuccessful_falseWhenPreparationFailedEvenIfStageSucceeded() {
+    var pipeline = pipelineWithSingleStage();
+    var status = PipelineStatus.createWithPreparationStatus(PipelineExecutionId.generate(), pipeline.pipelineId(),
+        Instant.now(), pipeline, PipelinePreparationStatus.finishedWithError("boom"));
+    var stageId = pipeline.stages().get(0).stageId();
+    status = PipelineStatus.withStageSuccess(status, stageId);
+
+    assertThat(status.isSuccessful()).isFalse();
+  }
+
+  @Test
+  void isFailed_trueWhenPreparationFailed() {
+    var pipeline = pipelineWithSingleStage();
+    var status = PipelineStatus.createWithPreparationStatus(PipelineExecutionId.generate(), pipeline.pipelineId(),
+        Instant.now(), pipeline, PipelinePreparationStatus.finishedWithError("boom"));
+
+    assertThat(status.isFailed()).isTrue();
+  }
+}

--- a/src/test/java/edu/stanford/protege/robot/pipeline/PipelineSuccessResultRepositoryTest.java
+++ b/src/test/java/edu/stanford/protege/robot/pipeline/PipelineSuccessResultRepositoryTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import edu.stanford.protege.robot.MongoTestExtension;
 import edu.stanford.protege.robot.command.annotate.PlainAnnotation;
 import edu.stanford.protege.robot.command.annotate.RobotAnnotateCommand;
 import edu.stanford.protege.robot.config.TestMongoConfiguration;
@@ -16,22 +15,34 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.semanticweb.owlapi.model.IRI;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.boot.test.autoconfigure.json.AutoConfigureJson;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
- * Integration tests for {@link PipelineSuccessResultRepository} using MongoTestExtension.
+ * Integration tests for {@link PipelineSuccessResultRepository} using Testcontainers.
  */
 @DataMongoTest
 @AutoConfigureJson
-@ExtendWith({MongoTestExtension.class})
+@Testcontainers
 @Import({JacksonConfiguration.class, TestMongoConfiguration.class})
 class PipelineSuccessResultRepositoryTest {
+
+  @Container
+  static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:7.0");
+
+  @DynamicPropertySource
+  static void setProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
+  }
 
   @Autowired
   private MongoTemplate mongoTemplate;

--- a/src/test/java/edu/stanford/protege/robot/service/RobotPipelineOrchestratorTest.java
+++ b/src/test/java/edu/stanford/protege/robot/service/RobotPipelineOrchestratorTest.java
@@ -1,0 +1,123 @@
+package edu.stanford.protege.robot.service;
+
+import edu.stanford.protege.robot.pipeline.*;
+import edu.stanford.protege.robot.service.snapshot.ProjectOntologySnapshot;
+import edu.stanford.protege.robot.service.snapshot.ProjectOntologySnapshotProvider;
+import edu.stanford.protege.webprotege.common.ProjectId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.semanticweb.owlapi.apibinding.OWLManager;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Focused tests for {@link RobotPipelineOrchestrator} behavior.
+ *
+ * <p>
+ * These tests run the orchestrator with a direct executor to make the async path
+ * synchronous and deterministic. That lets us assert the preparation-status
+ * transitions and verify snapshot success/failure wiring without involving
+ * real infrastructure.
+ */
+@ExtendWith(MockitoExtension.class)
+class RobotPipelineOrchestratorTest {
+
+    @Mock
+    private RobotPipelineExecutor executor;
+
+    @Mock
+    private ProjectOntologySnapshotProvider snapshotProvider;
+
+    @Mock
+    private PipelineStatusRepository statusRepository;
+
+    @Mock
+    private PipelineLogger pipelineLogger;
+
+    private RobotPipelineOrchestrator orchestrator;
+
+    private AtomicReference<PipelineStatus> lastStatus;
+
+    @BeforeEach
+    void setUp() {
+        lastStatus = new AtomicReference<>();
+        when(statusRepository.findStatus(any()))
+                .thenAnswer(invocation -> Optional.ofNullable(lastStatus.get()));
+        doAnswer(invocation -> {
+            lastStatus.set(invocation.getArgument(0));
+            return null;
+        }).when(statusRepository).saveStatus(any());
+        Executor directExecutor = Runnable::run;
+        orchestrator = new RobotPipelineOrchestrator(executor, snapshotProvider, statusRepository, pipelineLogger,
+                directExecutor);
+    }
+
+    /**
+     * Snapshot succeeds: preparation status transitions to success, and the
+     * pipeline executor is invoked with the snapshot ontology.
+     */
+    @Test
+    void executeAsync_snapshotSucceeds_updatesPreparationAndInvokesExecutor() throws Exception {
+        var projectId = ProjectId.generate();
+        var pipeline = new RobotPipeline(projectId, PipelineId.generate(), null, null, List.of());
+        var ontology = OWLManager.createOWLOntologyManager().createOntology();
+        when(snapshotProvider.createSnapshot(projectId)).thenReturn(new ProjectOntologySnapshot(ontology, 7L));
+
+        var executionId = orchestrator.executeAsync(projectId, pipeline);
+
+        assertThat(executionId).isNotNull();
+        verify(pipelineLogger).snapshotOntologyStarted(projectId, executionId, pipeline.pipelineId());
+        verify(pipelineLogger).snapshotOntologySucceeded(projectId, executionId, pipeline.pipelineId());
+        verify(executor).executePipeline(projectId, executionId, ontology, 7L, pipeline);
+
+        var statusCaptor = ArgumentCaptor.forClass(PipelineStatus.class);
+        verify(statusRepository, atLeast(3)).saveStatus(statusCaptor.capture());
+        var savedStatuses = statusCaptor.getAllValues();
+
+        assertThat(savedStatuses.get(0).preparationStatus())
+                .isEqualTo(PipelinePreparationStatus.waiting("Preparing ontology snapshot"));
+        assertThat(savedStatuses.get(1).preparationStatus())
+                .isEqualTo(PipelinePreparationStatus.running("Preparing ontology snapshot"));
+        assertThat(savedStatuses.get(savedStatuses.size() - 1).preparationStatus())
+                .isEqualTo(PipelinePreparationStatus.finishedWithSuccess("Ontology snapshot ready"));
+    }
+
+    /**
+     * Snapshot fails: preparation status is marked failed and ended,
+     * and the pipeline executor is not invoked.
+     */
+    @Test
+    void executeAsync_snapshotFails_updatesPreparationAndDoesNotInvokeExecutor() {
+        var projectId = ProjectId.generate();
+        var pipeline = new RobotPipeline(projectId, PipelineId.generate(), null, null, List.of());
+        when(snapshotProvider.createSnapshot(projectId)).thenThrow(new RuntimeException("deliberate failure"));
+
+        var executionId = orchestrator.executeAsync(projectId, pipeline);
+
+        assertThat(executionId).isNotNull();
+        verify(pipelineLogger).snapshotOntologyStarted(projectId, executionId, pipeline.pipelineId());
+        verify(pipelineLogger).snapshotOntologyFailed(eq(projectId), eq(executionId), eq(pipeline.pipelineId()), any());
+        verify(pipelineLogger).pipelineExecutionFinishedWithError(eq(projectId), eq(executionId), eq(pipeline.pipelineId()),
+                any());
+        verify(executor, never()).executePipeline(any(), any(), any(), anyLong(), any());
+
+        var statusCaptor = ArgumentCaptor.forClass(PipelineStatus.class);
+        verify(statusRepository, atLeast(3)).saveStatus(statusCaptor.capture());
+        var terminalStatus = statusCaptor.getAllValues()
+                .get(statusCaptor.getAllValues().size() - 1);
+        assertThat(terminalStatus.preparationStatus().status())
+                .isEqualTo(PipelinePreparationStatus.finishedWithError("Snapshot failed: deliberate failure").status());
+        assertThat(terminalStatus.endTime()).isNotNull();
+    }
+}

--- a/src/test/java/edu/stanford/protege/robot/service/snapshot/ProjectOntologySnapshotProviderTest.java
+++ b/src/test/java/edu/stanford/protege/robot/service/snapshot/ProjectOntologySnapshotProviderTest.java
@@ -1,0 +1,124 @@
+package edu.stanford.protege.robot.service.snapshot;
+
+import edu.stanford.protege.robot.service.exception.RobotServiceRuntimeException;
+import edu.stanford.protege.webprotege.common.ProjectId;
+import edu.stanford.protege.webprotege.revision.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyManager;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+/**
+ * Focused tests for {@link ProjectOntologySnapshotProvider}.
+ *
+ * <p>
+ * These tests cover the core behavior needed by the orchestrator: selecting an
+ * ontology from a revision, retrying when the head revision is ahead, and
+ * failing fast when the change history file is missing.
+ */
+class ProjectOntologySnapshotProviderTest {
+
+    @TempDir
+    Path tempDir;
+
+    private RevisionManagerFactory revisionManagerFactory;
+
+    private HeadRevisionNumberFinder headRevisionNumberFinder;
+
+    private ChangeHistoryFileFactory changeHistoryFileFactory;
+
+    private ProjectOntologySnapshotProvider snapshotProvider;
+
+    @BeforeEach
+    void setUp() {
+        revisionManagerFactory = mock(RevisionManagerFactory.class);
+        headRevisionNumberFinder = mock(HeadRevisionNumberFinder.class);
+        changeHistoryFileFactory = mock(ChangeHistoryFileFactory.class);
+        snapshotProvider = new ProjectOntologySnapshotProvider(revisionManagerFactory, headRevisionNumberFinder,
+                changeHistoryFileFactory);
+    }
+
+  /**
+   * Creates a snapshot from an available revision and returns the ontology
+   * chosen by the provider's selection strategy.
+   */
+  @Test
+  void createSnapshot_picksOntologyAndReturnsRevision() throws Exception {
+        var projectId = ProjectId.generate();
+        var historyFile = tempDir.resolve("changes.db").toFile();
+        assertThat(historyFile.createNewFile()).isTrue();
+        when(changeHistoryFileFactory.getChangeHistoryFile(projectId)).thenReturn(historyFile);
+
+        var revisionManager = mock(RevisionManager.class);
+        var revision = RevisionNumber.getRevisionNumber(3);
+        when(revisionManager.getCurrentRevision()).thenReturn(revision);
+        when(headRevisionNumberFinder.getHeadRevisionNumber(projectId)).thenReturn(revision);
+
+        var manager = OWLManager.createOWLOntologyManager();
+        var withoutIri = manager.createOntology();
+        var withIri = manager.createOntology(IRI.create("http://example.org/ontology"));
+        when(revisionManager.getOntologyManagerForRevision(revision)).thenReturn(manager);
+        when(revisionManagerFactory.createRevisionManager(projectId)).thenReturn(revisionManager);
+
+        var snapshot = snapshotProvider.createSnapshot(projectId);
+
+        assertThat(snapshot.revisionNumber()).isEqualTo(3L);
+        assertThat(Set.of(withoutIri, withIri)).contains(snapshot.ontology());
+        assertThat(snapshot.ontology()).isSameAs(withoutIri);
+    }
+
+  /**
+   * Retries the revision manager load when the head revision appears ahead,
+   * then proceeds once the head matches.
+   */
+  @Test
+  void createSnapshot_retriesWhenHeadRevisionAhead() throws Exception {
+        var projectId = ProjectId.generate();
+        var historyFile = tempDir.resolve("changes.db").toFile();
+        assertThat(historyFile.createNewFile()).isTrue();
+        when(changeHistoryFileFactory.getChangeHistoryFile(projectId)).thenReturn(historyFile);
+
+        var revisionManager = mock(RevisionManager.class);
+        var current = RevisionNumber.getRevisionNumber(3);
+        when(revisionManager.getCurrentRevision()).thenReturn(current);
+        when(revisionManagerFactory.createRevisionManager(projectId)).thenReturn(revisionManager);
+        when(headRevisionNumberFinder.getHeadRevisionNumber(projectId))
+                .thenReturn(RevisionNumber.getRevisionNumber(5))
+                .thenReturn(current);
+
+        var manager = OWLManager.createOWLOntologyManager();
+        manager.createOntology();
+        when(revisionManager.getOntologyManagerForRevision(current)).thenReturn(manager);
+
+        var snapshot = snapshotProvider.createSnapshot(projectId);
+
+        assertThat(snapshot.revisionNumber()).isEqualTo(3L);
+        verify(revisionManagerFactory, times(2)).createRevisionManager(projectId);
+        verify(headRevisionNumberFinder, times(2)).getHeadRevisionNumber(projectId);
+    }
+
+  /**
+   * Fails fast when the change history file is missing.
+   */
+  @Test
+  void createSnapshot_throwsWhenHistoryFileMissing() {
+        var projectId = ProjectId.generate();
+        var historyFile = tempDir.resolve("missing.db").toFile();
+        when(changeHistoryFileFactory.getChangeHistoryFile(projectId)).thenReturn(historyFile);
+
+        assertThatThrownBy(() -> snapshotProvider.createSnapshot(projectId))
+                .isInstanceOf(RobotServiceRuntimeException.class)
+                .hasMessageContaining("Change history file not found");
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,10 @@
+logging:
+  level:
+    org.mongodb.driver: WARN
+    org.mongodb.driver.cluster: WARN
+    org.testcontainers: WARN
+    org.testcontainers.containers: WARN
+    org.testcontainers.utility: WARN
+spring:
+  main:
+    banner-mode: "off"

--- a/src/test/resources/docker-java.properties
+++ b/src/test/resources/docker-java.properties
@@ -1,0 +1,1 @@
+api.version=1.44

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-subclass


### PR DESCRIPTION
## Summary

- add pipeline snapshot orchestration with preparation status tracking and lifecycle events
- refactor executor to consume snapshot ontologies directly and wire revision-manager snapshot provider
- configure pipeline executor thread pool defaults and data directory
- migrate Mongo integration tests to Testcontainers and add focused unit tests for new behavior
- reduce test log noise and pin docker-java API version for Testcontainers reliability

## Testing

- mvn test (passes with Docker)
- mvn -Dtest=RobotPipelineOrchestratorTest,ProjectOntologySnapshotProviderTest,PipelineStatusTest test
