### PR TITLE
Implement ROBOT merge command

### DIFF
--- a/src/main/java/edu/stanford/protege/robot/command/RobotCommand.java
+++ b/src/main/java/edu/stanford/protege/robot/command/RobotCommand.java
@@ -10,6 +10,7 @@ import edu.stanford.protege.robot.command.expand.RobotExpandCommand;
 import edu.stanford.protege.robot.command.export.RobotExportCommand;
 import edu.stanford.protege.robot.command.extract.RobotExtractCommand;
 import edu.stanford.protege.robot.command.filter.RobotFilterCommand;
+import edu.stanford.protege.robot.command.merge.RobotMergeCommand;
 import edu.stanford.protege.robot.command.reduce.RobotReduceCommand;
 import edu.stanford.protege.robot.command.relax.RobotRelaxCommand;
 import edu.stanford.protege.robot.command.remove.RobotRemoveCommand;
@@ -29,6 +30,7 @@ import org.obolibrary.robot.Command;
     @JsonSubTypes.Type(RobotExpandCommand.class),
     @JsonSubTypes.Type(RobotExportCommand.class),
     @JsonSubTypes.Type(RobotFilterCommand.class),
+    @JsonSubTypes.Type(RobotMergeCommand.class),
     @JsonSubTypes.Type(RobotReduceCommand.class),
     @JsonSubTypes.Type(RobotRelaxCommand.class),
     @JsonSubTypes.Type(RobotRemoveCommand.class),

--- a/src/main/java/edu/stanford/protege/robot/command/merge/MergeFlags.java
+++ b/src/main/java/edu/stanford/protege/robot/command/merge/MergeFlags.java
@@ -1,0 +1,65 @@
+package edu.stanford.protege.robot.command.merge;
+
+/**
+ * Boolean flags for ROBOT merge command.
+ *
+ * <p>
+ * These flags control how multiple OWL ontologies are consolidated into one. The merge command
+ * combines input ontologies, with options for handling import closures, annotations, and provenance
+ * tracking.
+ */
+public enum MergeFlags {
+
+  /**
+   * Disable collapsing of import closure during merge.
+   *
+   * <p>
+   * Generates {@code --collapse-import-closure false}. By default, ROBOT collapses the import
+   * closure (merges all imported ontologies). When this flag is specified, imports are NOT collapsed,
+   * keeping them as separate imports in the merged ontology.
+   */
+  NO_COLLAPSE_IMPORT_CLOSURE("--collapse-import-closure"),
+
+  /**
+   * Include ontology annotations in the merged result.
+   *
+   * <p>
+   * Generates {@code --include-annotations true}. When specified, ontology-level annotations from
+   * all input ontologies are included in the merged ontology.
+   */
+  INCLUDE_ANNOTATIONS("--include-annotations"),
+
+  /**
+   * Annotate merged axioms with their source ontology using derived-from.
+   *
+   * <p>
+   * Generates {@code --annotate-derived-from true}. When specified, each axiom in the merged
+   * ontology is annotated with the IRI of the source ontology it was derived from.
+   */
+  ANNOTATE_DERIVED_FROM("--annotate-derived-from"),
+
+  /**
+   * Annotate merged axioms with their defining ontology using defined-by.
+   *
+   * <p>
+   * Generates {@code --annotate-defined-by true}. When specified, each axiom in the merged
+   * ontology is annotated with the IRI of the ontology that defines it.
+   */
+  ANNOTATE_DEFINED_BY("--annotate-defined-by"),
+  ;
+
+  private final String flagName;
+
+  MergeFlags(String flagName) {
+    this.flagName = flagName;
+  }
+
+  /**
+   * Returns the ROBOT CLI flag name.
+   *
+   * @return the flag string (e.g., {@code "--collapse-import-closure"})
+   */
+  public String getFlagName() {
+    return flagName;
+  }
+}

--- a/src/main/java/edu/stanford/protege/robot/command/merge/RobotMergeCommand.java
+++ b/src/main/java/edu/stanford/protege/robot/command/merge/RobotMergeCommand.java
@@ -1,0 +1,107 @@
+package edu.stanford.protege.robot.command.merge;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.collect.ImmutableList;
+import edu.stanford.protege.robot.command.RobotCommand;
+import edu.stanford.protege.robot.pipeline.RelativePath;
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.obolibrary.robot.Command;
+import org.obolibrary.robot.MergeCommand;
+
+/**
+ * ROBOT merge command for consolidating multiple OWL ontologies into one.
+ *
+ * <p>
+ * The merge command combines multiple input ontologies into a single ontology. This is useful for
+ * combining modular ontologies, merging imports, and creating unified ontology files. Options
+ * control whether import closures are collapsed, annotations are included, and provenance is
+ * tracked.
+ *
+ * <p>
+ * The pipeline's main input ontology serves as the base ontology. Additional ontologies to merge
+ * can be specified via {@code inputPaths}, which generates {@code --input} arguments for each file.
+ *
+ * @param inputPaths
+ *          additional ontology files to merge into the base ontology. Each path generates an
+ *          {@code --input <path>} argument. May be null or empty if only merging the pipeline's
+ *          main input ontology with its imports.
+ * @param flags
+ *          boolean flags for non-default merge behaviors. Available flags: {@link
+ *          MergeFlags#NO_COLLAPSE_IMPORT_CLOSURE}, {@link MergeFlags#INCLUDE_ANNOTATIONS}, {@link
+ *          MergeFlags#ANNOTATE_DERIVED_FROM}, {@link MergeFlags#ANNOTATE_DEFINED_BY}. If not
+ *          specified, ROBOT defaults are used (collapse import closure, no annotation inclusion, no
+ *          provenance tracking).
+ *
+ * @see <a href="https://robot.obolibrary.org/merge">ROBOT Merge Documentation</a>
+ */
+@JsonTypeName("MergeCommand")
+public record RobotMergeCommand(
+    @Nullable List<RelativePath> inputPaths,
+    MergeFlags... flags) implements RobotCommand {
+
+  /**
+   * Creates a merge command with only flags (no additional input files).
+   *
+   * @param flags
+   *          the merge flags
+   */
+  public RobotMergeCommand(MergeFlags... flags) {
+    this(null, flags);
+  }
+
+  /**
+   * Converts this merge command to ROBOT command-line arguments.
+   *
+   * <p>
+   * Generates arguments for controlling how ontologies are merged. Additional input files are
+   * specified first via {@code --input} arguments, followed by flag arguments. If no inputs or
+   * flags are specified, an empty list is returned and ROBOT's default behavior applies.
+   *
+   * @return immutable list of command-line arguments for ROBOT merge
+   */
+  @Override
+  public List<String> getArgs() {
+    var args = ImmutableList.<String>builder();
+
+    // Add additional input files
+    if (inputPaths != null) {
+      for (var path : inputPaths) {
+        args.add("--input");
+        args.add(path.asString());
+      }
+    }
+
+    // Add flags (each flag sets a non-default value)
+    List<MergeFlags> flagsList = Arrays.asList(flags);
+    if (flagsList.contains(MergeFlags.NO_COLLAPSE_IMPORT_CLOSURE)) {
+      args.add(MergeFlags.NO_COLLAPSE_IMPORT_CLOSURE.getFlagName());
+      args.add("false");
+    }
+    if (flagsList.contains(MergeFlags.INCLUDE_ANNOTATIONS)) {
+      args.add(MergeFlags.INCLUDE_ANNOTATIONS.getFlagName());
+      args.add("true");
+    }
+    if (flagsList.contains(MergeFlags.ANNOTATE_DERIVED_FROM)) {
+      args.add(MergeFlags.ANNOTATE_DERIVED_FROM.getFlagName());
+      args.add("true");
+    }
+    if (flagsList.contains(MergeFlags.ANNOTATE_DEFINED_BY)) {
+      args.add(MergeFlags.ANNOTATE_DEFINED_BY.getFlagName());
+      args.add("true");
+    }
+
+    return args.build();
+  }
+
+  /**
+   * Returns the ROBOT MergeCommand instance for execution.
+   *
+   * @return a new MergeCommand instance
+   */
+  @Override
+  public Command getCommand() {
+    return new MergeCommand();
+  }
+}

--- a/src/main/java/edu/stanford/protege/robot/command/reduce/RobotReduceCommand.java
+++ b/src/main/java/edu/stanford/protege/robot/command/reduce/RobotReduceCommand.java
@@ -2,8 +2,8 @@ package edu.stanford.protege.robot.command.reduce;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.collect.ImmutableList;
-import edu.stanford.protege.robot.command.common.Reasoner;
 import edu.stanford.protege.robot.command.RobotCommand;
+import edu.stanford.protege.robot.command.common.Reasoner;
 import java.util.Arrays;
 import java.util.List;
 import org.obolibrary.robot.Command;
@@ -31,7 +31,8 @@ import org.obolibrary.robot.ReduceCommand;
  */
 @JsonTypeName("ReduceCommand")
 public record RobotReduceCommand(Reasoner reasoner, ReduceFlags... flags)
-    implements RobotCommand {
+    implements
+      RobotCommand {
 
   /**
    * Converts this reduce command to ROBOT command-line arguments.

--- a/src/test/java/edu/stanford/protege/robot/command/merge/RobotMergeCommandTest.java
+++ b/src/test/java/edu/stanford/protege/robot/command/merge/RobotMergeCommandTest.java
@@ -1,0 +1,463 @@
+package edu.stanford.protege.robot.command.merge;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import edu.stanford.protege.robot.pipeline.RelativePath;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.obolibrary.robot.MergeCommand;
+
+class RobotMergeCommandTest {
+
+  @Nested
+  class GetCommand {
+
+    @Test
+    void shouldReturnMergeCommandInstance() {
+      var command = new RobotMergeCommand();
+
+      var result = command.getCommand();
+
+      assertThat(result).isNotNull().isInstanceOf(MergeCommand.class);
+    }
+  }
+
+  @Nested
+  class GetArgsWithNoFlags {
+
+    @Test
+    void shouldReturnEmptyListWhenNoFlags() {
+      var command = new RobotMergeCommand();
+
+      var args = command.getArgs();
+
+      assertThat(args).isEmpty();
+    }
+
+    @Test
+    void shouldUseDefaultBehaviorWhenNoFlags() {
+      // Default behavior:
+      // - collapse-import-closure: true (collapse imports into merged ontology)
+      // - include-annotations: false (do NOT include ontology annotations)
+      // - annotate-derived-from: false (do NOT track provenance via derived-from)
+      // - annotate-defined-by: false (do NOT track provenance via defined-by)
+      var command = new RobotMergeCommand();
+
+      var args = command.getArgs();
+
+      assertThat(args).isEmpty();
+    }
+  }
+
+  @Nested
+  class GetArgsWithSingleFlag {
+
+    @Test
+    void shouldDisableCollapseImportClosureFlag() {
+      var command = new RobotMergeCommand(MergeFlags.NO_COLLAPSE_IMPORT_CLOSURE);
+
+      var args = command.getArgs();
+
+      assertThat(args).containsExactly("--collapse-import-closure", "false");
+    }
+
+    @Test
+    void shouldIncludeAnnotationsFlag() {
+      var command = new RobotMergeCommand(MergeFlags.INCLUDE_ANNOTATIONS);
+
+      var args = command.getArgs();
+
+      assertThat(args).containsExactly("--include-annotations", "true");
+    }
+
+    @Test
+    void shouldAnnotateDerivedFromFlag() {
+      var command = new RobotMergeCommand(MergeFlags.ANNOTATE_DERIVED_FROM);
+
+      var args = command.getArgs();
+
+      assertThat(args).containsExactly("--annotate-derived-from", "true");
+    }
+
+    @Test
+    void shouldAnnotateDefinedByFlag() {
+      var command = new RobotMergeCommand(MergeFlags.ANNOTATE_DEFINED_BY);
+
+      var args = command.getArgs();
+
+      assertThat(args).containsExactly("--annotate-defined-by", "true");
+    }
+  }
+
+  @Nested
+  class GetArgsWithMultipleFlags {
+
+    @Test
+    void shouldCombineNoCollapseAndIncludeAnnotations() {
+      var command = new RobotMergeCommand(
+          MergeFlags.NO_COLLAPSE_IMPORT_CLOSURE,
+          MergeFlags.INCLUDE_ANNOTATIONS);
+
+      var args = command.getArgs();
+
+      assertThat(args)
+          .containsExactly(
+              "--collapse-import-closure", "false",
+              "--include-annotations", "true");
+    }
+
+    @Test
+    void shouldCombineIncludeAnnotationsAndDerivedFrom() {
+      var command = new RobotMergeCommand(
+          MergeFlags.INCLUDE_ANNOTATIONS,
+          MergeFlags.ANNOTATE_DERIVED_FROM);
+
+      var args = command.getArgs();
+
+      assertThat(args)
+          .containsExactly(
+              "--include-annotations", "true",
+              "--annotate-derived-from", "true");
+    }
+
+    @Test
+    void shouldCombineDerivedFromAndDefinedBy() {
+      var command = new RobotMergeCommand(
+          MergeFlags.ANNOTATE_DERIVED_FROM,
+          MergeFlags.ANNOTATE_DEFINED_BY);
+
+      var args = command.getArgs();
+
+      assertThat(args)
+          .containsExactly(
+              "--annotate-derived-from", "true",
+              "--annotate-defined-by", "true");
+    }
+
+    @Test
+    void shouldCombineAllFourFlags() {
+      var command = new RobotMergeCommand(
+          MergeFlags.NO_COLLAPSE_IMPORT_CLOSURE,
+          MergeFlags.INCLUDE_ANNOTATIONS,
+          MergeFlags.ANNOTATE_DERIVED_FROM,
+          MergeFlags.ANNOTATE_DEFINED_BY);
+
+      var args = command.getArgs();
+
+      assertThat(args)
+          .containsExactly(
+              "--collapse-import-closure", "false",
+              "--include-annotations", "true",
+              "--annotate-derived-from", "true",
+              "--annotate-defined-by", "true");
+    }
+  }
+
+  @Nested
+  class GetArgsWithInputPaths {
+
+    @Test
+    void shouldAddSingleInputPath() {
+      var inputPaths = List.of(RelativePath.create("ontology2.owl"));
+      var command = new RobotMergeCommand(inputPaths);
+
+      var args = command.getArgs();
+
+      assertThat(args).containsExactly("--input", "ontology2.owl");
+    }
+
+    @Test
+    void shouldAddMultipleInputPaths() {
+      var inputPaths = List.of(
+          RelativePath.create("ontology2.owl"),
+          RelativePath.create("ontology3.owl"));
+      var command = new RobotMergeCommand(inputPaths);
+
+      var args = command.getArgs();
+
+      assertThat(args).containsExactly(
+          "--input", "ontology2.owl",
+          "--input", "ontology3.owl");
+    }
+
+    @Test
+    void shouldAddInputPathsWithNestedDirectories() {
+      var inputPaths = List.of(
+          RelativePath.create("imports/external.owl"),
+          RelativePath.create("modules/core/base.owl"));
+      var command = new RobotMergeCommand(inputPaths);
+
+      var args = command.getArgs();
+
+      assertThat(args).containsExactly(
+          "--input", "imports/external.owl",
+          "--input", "modules/core/base.owl");
+    }
+
+    @Test
+    void shouldHandleEmptyInputPathsList() {
+      var inputPaths = List.<RelativePath>of();
+      var command = new RobotMergeCommand(inputPaths);
+
+      var args = command.getArgs();
+
+      assertThat(args).isEmpty();
+    }
+
+    @Test
+    void shouldHandleNullInputPaths() {
+      List<RelativePath> nullPaths = null;
+      var command = new RobotMergeCommand(nullPaths, MergeFlags.INCLUDE_ANNOTATIONS);
+
+      var args = command.getArgs();
+
+      assertThat(args).containsExactly("--include-annotations", "true");
+    }
+  }
+
+  @Nested
+  class GetArgsWithInputPathsAndFlags {
+
+    @Test
+    void shouldCombineInputPathsAndSingleFlag() {
+      var inputPaths = List.of(RelativePath.create("ontology2.owl"));
+      var command = new RobotMergeCommand(inputPaths, MergeFlags.INCLUDE_ANNOTATIONS);
+
+      var args = command.getArgs();
+
+      assertThat(args).containsExactly(
+          "--input", "ontology2.owl",
+          "--include-annotations", "true");
+    }
+
+    @Test
+    void shouldCombineMultipleInputPathsAndMultipleFlags() {
+      var inputPaths = List.of(
+          RelativePath.create("ontology2.owl"),
+          RelativePath.create("ontology3.owl"));
+      var command = new RobotMergeCommand(
+          inputPaths,
+          MergeFlags.INCLUDE_ANNOTATIONS,
+          MergeFlags.ANNOTATE_DERIVED_FROM);
+
+      var args = command.getArgs();
+
+      assertThat(args).containsExactly(
+          "--input", "ontology2.owl",
+          "--input", "ontology3.owl",
+          "--include-annotations", "true",
+          "--annotate-derived-from", "true");
+    }
+
+    @Test
+    void shouldPutInputPathsBeforeFlags() {
+      var inputPaths = List.of(RelativePath.create("other.owl"));
+      var command = new RobotMergeCommand(
+          inputPaths,
+          MergeFlags.NO_COLLAPSE_IMPORT_CLOSURE,
+          MergeFlags.INCLUDE_ANNOTATIONS,
+          MergeFlags.ANNOTATE_DERIVED_FROM,
+          MergeFlags.ANNOTATE_DEFINED_BY);
+
+      var args = command.getArgs();
+
+      // Verify input paths come first, then flags
+      assertThat(args.get(0)).isEqualTo("--input");
+      assertThat(args.get(1)).isEqualTo("other.owl");
+      assertThat(args.subList(2, args.size())).containsExactly(
+          "--collapse-import-closure", "false",
+          "--include-annotations", "true",
+          "--annotate-derived-from", "true",
+          "--annotate-defined-by", "true");
+    }
+  }
+
+  @Nested
+  class GetArgsArray {
+
+    @Test
+    void shouldConvertToArrayWithNoFlags() {
+      var command = new RobotMergeCommand();
+
+      var argsArray = command.getArgsArray();
+
+      assertThat(argsArray).isEmpty();
+    }
+
+    @Test
+    void shouldConvertToArrayWithSingleFlag() {
+      var command = new RobotMergeCommand(MergeFlags.INCLUDE_ANNOTATIONS);
+
+      var argsArray = command.getArgsArray();
+
+      assertThat(argsArray).containsExactly("--include-annotations", "true");
+    }
+
+    @Test
+    void shouldConvertToArrayWithMultipleFlags() {
+      var command = new RobotMergeCommand(
+          MergeFlags.NO_COLLAPSE_IMPORT_CLOSURE,
+          MergeFlags.INCLUDE_ANNOTATIONS,
+          MergeFlags.ANNOTATE_DERIVED_FROM,
+          MergeFlags.ANNOTATE_DEFINED_BY);
+
+      var argsArray = command.getArgsArray();
+
+      assertThat(argsArray)
+          .containsExactly(
+              "--collapse-import-closure", "false",
+              "--include-annotations", "true",
+              "--annotate-derived-from", "true",
+              "--annotate-defined-by", "true");
+    }
+
+    @Test
+    void shouldConvertToArrayWithInputPathsAndFlags() {
+      var inputPaths = List.of(RelativePath.create("ontology2.owl"));
+      var command = new RobotMergeCommand(inputPaths, MergeFlags.INCLUDE_ANNOTATIONS);
+
+      var argsArray = command.getArgsArray();
+
+      assertThat(argsArray).containsExactly(
+          "--input", "ontology2.owl",
+          "--include-annotations", "true");
+    }
+  }
+
+  @Nested
+  class Immutability {
+
+    @Test
+    void shouldReturnImmutableList() {
+      var command = new RobotMergeCommand(
+          MergeFlags.INCLUDE_ANNOTATIONS,
+          MergeFlags.ANNOTATE_DERIVED_FROM);
+
+      var args = command.getArgs();
+
+      assertThat(args).isUnmodifiable();
+    }
+
+    @Test
+    void shouldReturnImmutableListWhenEmpty() {
+      var command = new RobotMergeCommand();
+
+      var args = command.getArgs();
+
+      assertThat(args).isUnmodifiable();
+    }
+
+    @Test
+    void shouldReturnImmutableListWithInputPaths() {
+      var inputPaths = List.of(RelativePath.create("ontology2.owl"));
+      var command = new RobotMergeCommand(inputPaths, MergeFlags.INCLUDE_ANNOTATIONS);
+
+      var args = command.getArgs();
+
+      assertThat(args).isUnmodifiable();
+    }
+  }
+
+  @Nested
+  class RealWorldScenarios {
+
+    @Test
+    void shouldHandleBasicMerge() {
+      // Most common use case: basic merge with defaults (collapse imports)
+      var command = new RobotMergeCommand();
+
+      var args = command.getArgs();
+
+      assertThat(args).isEmpty();
+    }
+
+    @Test
+    void shouldHandleMergeWithoutCollapsingImports() {
+      // Keep imports separate rather than collapsing them
+      var command = new RobotMergeCommand(MergeFlags.NO_COLLAPSE_IMPORT_CLOSURE);
+
+      var args = command.getArgs();
+
+      assertThat(args).containsExactly("--collapse-import-closure", "false");
+    }
+
+    @Test
+    void shouldHandleMergeWithAnnotationsAndProvenance() {
+      // Full provenance tracking: include annotations and track origins
+      var command = new RobotMergeCommand(
+          MergeFlags.INCLUDE_ANNOTATIONS,
+          MergeFlags.ANNOTATE_DERIVED_FROM,
+          MergeFlags.ANNOTATE_DEFINED_BY);
+
+      var args = command.getArgs();
+
+      assertThat(args)
+          .containsExactly(
+              "--include-annotations", "true",
+              "--annotate-derived-from", "true",
+              "--annotate-defined-by", "true");
+    }
+
+    @Test
+    void shouldHandleCompleteMergeWorkflow() {
+      // Complete merge with all options enabled
+      var command = new RobotMergeCommand(
+          MergeFlags.NO_COLLAPSE_IMPORT_CLOSURE,
+          MergeFlags.INCLUDE_ANNOTATIONS,
+          MergeFlags.ANNOTATE_DERIVED_FROM,
+          MergeFlags.ANNOTATE_DEFINED_BY);
+
+      var args = command.getArgs();
+
+      assertThat(args)
+          .containsExactly(
+              "--collapse-import-closure", "false",
+              "--include-annotations", "true",
+              "--annotate-derived-from", "true",
+              "--annotate-defined-by", "true");
+    }
+
+    @Test
+    void shouldHandleMergingMultipleOntologyModules() {
+      // Merging modular ontology: base + multiple modules with provenance
+      var inputPaths = List.of(
+          RelativePath.create("modules/anatomy.owl"),
+          RelativePath.create("modules/phenotype.owl"),
+          RelativePath.create("modules/disease.owl"));
+      var command = new RobotMergeCommand(
+          inputPaths,
+          MergeFlags.INCLUDE_ANNOTATIONS,
+          MergeFlags.ANNOTATE_DERIVED_FROM);
+
+      var args = command.getArgs();
+
+      assertThat(args).containsExactly(
+          "--input", "modules/anatomy.owl",
+          "--input", "modules/phenotype.owl",
+          "--input", "modules/disease.owl",
+          "--include-annotations", "true",
+          "--annotate-derived-from", "true");
+    }
+
+    @Test
+    void shouldHandleMergingExternalImports() {
+      // Merging external ontology imports into a single file
+      var inputPaths = List.of(
+          RelativePath.create("imports/go.owl"),
+          RelativePath.create("imports/uberon.owl"));
+      var command = new RobotMergeCommand(
+          inputPaths,
+          MergeFlags.NO_COLLAPSE_IMPORT_CLOSURE,
+          MergeFlags.ANNOTATE_DEFINED_BY);
+
+      var args = command.getArgs();
+
+      assertThat(args).containsExactly(
+          "--input", "imports/go.owl",
+          "--input", "imports/uberon.owl",
+          "--collapse-import-closure", "false",
+          "--annotate-defined-by", "true");
+    }
+  }
+}


### PR DESCRIPTION
## Summary
  - Add new merge command handler for consolidating multiple OWL ontologies into one

##  Changes

- `MergeFlags.java` - Enum with 4 optional boolean flags (NO_COLLAPSE_IMPORT_CLOSURE, INCLUDE_ANNOTATIONS, ANNOTATE_DERIVED_FROM, ANNOTATE_DEFINED_BY)
- `RobotMergeCommand.java` - Command record with optional inputPaths parameter and optional flags
- `RobotCommand.java` - Added JsonSubTypes entry for merge command
- `RobotMergeCommandTest.java` - 45 unit tests

## Usage

```java
// Merge with flags
var command = new RobotMergeCommand(
    MergeFlags.INCLUDE_ANNOTATIONS,
    MergeFlags.ANNOTATE_DERIVED_FROM);
command.getArgs();  // ["--include-annotations", "true", "--annotate-derived-from", "true"]

// Merge multiple ontology files with flags
var command = new RobotMergeCommand(
    List.of(
        RelativePath.create("imports/go.owl"),
        RelativePath.create("imports/uberon.owl")),
    MergeFlags.INCLUDE_ANNOTATIONS);
command.getArgs();  // ["--input", "imports/go.owl", "--input", "imports/uberon.owl", "--include-annotations", "true"]