### PR TITLE
Add context-load test and test defaults

### DIFF
--- a/src/main/java/edu/stanford/protege/robot/service/RobotPipelineOrchestrator.java
+++ b/src/main/java/edu/stanford/protege/robot/service/RobotPipelineOrchestrator.java
@@ -39,7 +39,7 @@ public class RobotPipelineOrchestrator {
       ProjectOntologySnapshotProvider snapshotProvider,
       PipelineStatusRepository pipelineStatusRepository,
       PipelineLogger pipelineLogger,
-                                     @Qualifier("robotPipelineTaskExecutor") Executor pipelineExecutor) {
+      @Qualifier("robotPipelineTaskExecutor") Executor pipelineExecutor) {
     this.executor = executor;
     this.snapshotProvider = snapshotProvider;
     this.pipelineStatusRepository = pipelineStatusRepository;

--- a/src/main/java/edu/stanford/protege/robot/service/RobotPipelineOrchestrator.java
+++ b/src/main/java/edu/stanford/protege/robot/service/RobotPipelineOrchestrator.java
@@ -39,7 +39,7 @@ public class RobotPipelineOrchestrator {
       ProjectOntologySnapshotProvider snapshotProvider,
       PipelineStatusRepository pipelineStatusRepository,
       PipelineLogger pipelineLogger,
-      @Qualifier("robotPipelineExecutor") Executor pipelineExecutor) {
+                                     @Qualifier("robotPipelineTaskExecutor") Executor pipelineExecutor) {
     this.executor = executor;
     this.snapshotProvider = snapshotProvider;
     this.pipelineStatusRepository = pipelineStatusRepository;

--- a/src/main/java/edu/stanford/protege/robot/service/config/RevisionManagerConfiguration.java
+++ b/src/main/java/edu/stanford/protege/robot/service/config/RevisionManagerConfiguration.java
@@ -12,7 +12,6 @@ import org.semanticweb.owlapi.model.OWLDataFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import uk.ac.manchester.cs.owl.owlapi.OWLDataFactoryImpl;
 
 @Configuration
 public class RevisionManagerConfiguration {

--- a/src/main/java/edu/stanford/protege/robot/service/config/RevisionManagerConfiguration.java
+++ b/src/main/java/edu/stanford/protege/robot/service/config/RevisionManagerConfiguration.java
@@ -18,11 +18,6 @@ import uk.ac.manchester.cs.owl.owlapi.OWLDataFactoryImpl;
 public class RevisionManagerConfiguration {
 
   @Bean
-  OWLDataFactory dataFactory() {
-    return new OWLDataFactoryImpl();
-  }
-
-  @Bean
   OntologyChangeRecordTranslator ontologyChangeRecordTranslator() {
     return new OntologyChangeRecordTranslatorImpl();
   }

--- a/src/main/java/edu/stanford/protege/robot/service/config/RobotPipelineExecutorConfiguration.java
+++ b/src/main/java/edu/stanford/protege/robot/service/config/RobotPipelineExecutorConfiguration.java
@@ -10,8 +10,8 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 @EnableConfigurationProperties(RobotPipelineExecutorProperties.class)
 public class RobotPipelineExecutorConfiguration {
 
-  @Bean
-  Executor robotPipelineExecutor(RobotPipelineExecutorProperties properties) {
+  @Bean(name = "robotPipelineTaskExecutor")
+  Executor robotPipelineTaskExecutor(RobotPipelineExecutorProperties properties) {
     var executor = new ThreadPoolTaskExecutor();
     executor.setCorePoolSize(properties.getCorePoolSize());
     executor.setMaxPoolSize(properties.getMaxPoolSize());

--- a/src/test/java/edu/stanford/protege/robot/WebProtegeRobotServiceApplicationTest.java
+++ b/src/test/java/edu/stanford/protege/robot/WebProtegeRobotServiceApplicationTest.java
@@ -1,0 +1,23 @@
+package edu.stanford.protege.robot;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+@SpringBootTest
+class WebProtegeRobotServiceApplicationTest {
+
+  @TempDir
+  static Path tempDir;
+
+  @DynamicPropertySource
+  static void registerProperties(DynamicPropertyRegistry registry) {
+    registry.add("webprotege.directories.data", () -> tempDir.toString());
+  }
+
+  @Test
+  void contextLoads() {}
+}

--- a/src/test/java/edu/stanford/protege/robot/WebProtegeRobotServiceApplicationTest.java
+++ b/src/test/java/edu/stanford/protege/robot/WebProtegeRobotServiceApplicationTest.java
@@ -19,5 +19,6 @@ class WebProtegeRobotServiceApplicationTest {
   }
 
   @Test
-  void contextLoads() {}
+  void contextLoads() {
+  }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -6,5 +6,23 @@ logging:
     org.testcontainers.containers: WARN
     org.testcontainers.utility: WARN
 spring:
+  application:
+    name: webprotege-robot-service-test
+  rabbitmq:
+    host: localhost
+    port: 5672
+    username: guest
+    password: guest
   main:
     banner-mode: "off"
+webprotege:
+  rabbitmq:
+    requestqueue: webprotege-robot-queue
+    responsequeue: webprotege-robot-response-queue
+    timeout: 60000
+    commands-subscribe: false
+  minio:
+    end-point: http://localhost:9000
+    access-key: test
+    secret-key: test
+    robot-output-documents-bucket-name: robot-output


### PR DESCRIPTION
## Summary\n- add a Spring Boot context-load test with a temp data directory override\n- move test-only MinIO/RabbitMQ defaults into src/test/resources/application.yml\n- disable RabbitMQ command subscriptions in tests to avoid connection attempts\n- align executor bean naming and qualifiers to avoid bean definition clashes\n\n## Testing\n- mvn -Dtest=WebProtegeRobotServiceApplicationTest test\n