### PR TITLE
Bump webprotege-revision-manager to 0.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>edu.stanford.protege</groupId>
             <artifactId>webprotege-revision-manager</artifactId>
-            <version>0.9.2</version>
+            <version>0.10.0</version>
         </dependency>
 
         <!-- MinIO -->


### PR DESCRIPTION
## Summary\n- update webprotege-revision-manager dependency from 0.9.2 to 0.10.0\n\n## Testing\n- not run (dependency bump only)\n